### PR TITLE
Improve cert API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,10 +141,6 @@ tags
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "files.associations": {
-        "array": "c",
-        "string": "c",
-        "string_view": "c",
-        "span": "c"
-    }
-}

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Make sure you have it installed on your OS.
 Init `ExDTLS` on both peers with:
 
 ```elixir
-# One peer should be a client and use client_mode: true, the other - false
-# DTLS-SRTP is the most common use case for ExDTLS, we'll enable it
-dtls = ExDTLS.init(client_mode: true, dtls_srtp: true)
+# One peer should be a client (use `mode: :client`) and the other 
+# one a server (use `mode: :server`). 
+# DTLS-SRTP is the most common use case for ExDTLS, we'll enable it.
+dtls = ExDTLS.init(mode: :client, dtls_srtp: true)
 ```
 
 On a peer running in a client mode start performing DTLS handshake

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ return `{:handshake_finished, local_keying_material, remote_keying_material, pro
 For more complete examples please refer to [ex_webrtc] where we use `ex_dtls`
 or to our integration tests.
 
+## Debugging
+
+Add `compiler_flags: ["-DEXDTLS_DEBUG"],` in `bundlex.exs` to
+get debug logs from the native code.
+
 ## Copyright and License
 
 Copyright 2020, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=ex_dtls)

--- a/bundlex.exs
+++ b/bundlex.exs
@@ -15,6 +15,7 @@ defmodule ExDTLS.BundlexProject do
         pkg_configs: ["openssl"],
         libs: ["pthread"],
         interface: [:nif],
+        # compiler_flags: ["-DEXDTLS_DEBUG"],
         preprocessor: Unifex
       ]
     ]

--- a/c_src/ex_dtls/dtls.c
+++ b/c_src/ex_dtls/dtls.c
@@ -198,3 +198,12 @@ X509 *decode_cert(unsigned char *buf, int len) {
   p = buf;
   return d2i_X509(NULL, &p, len);
 }
+
+int get_timeout(SSL *ssl) {
+  struct timeval timeout;
+  int timeout_ms = 0;
+  if (DTLSv1_get_timeout(ssl, &timeout) == 1) {
+    timeout_ms = timeout.tv_sec * 1000 + (timeout.tv_usec / 1000);
+  }
+  return timeout_ms;
+}

--- a/c_src/ex_dtls/dtls.c
+++ b/c_src/ex_dtls/dtls.c
@@ -19,16 +19,18 @@ SSL_CTX *create_ctx(int dtls_srtp) {
   return ssl_ctx;
 }
 
-SSL *create_ssl(SSL_CTX *ssl_ctx, int client_mode) {
+SSL *create_ssl(SSL_CTX *ssl_ctx, int mode) {
   SSL *ssl = SSL_new(ssl_ctx);
   if (ssl == NULL) {
     return NULL;
   }
 
-  if (client_mode) {
+  if (mode == MODE_CLIENT) {
     SSL_set_connect_state(ssl);
-  } else {
+  } else if (mode == MODE_SERVER) {
     SSL_set_accept_state(ssl);
+  } else {
+    return NULL;
   }
 
   BIO *rbio = BIO_new(BIO_s_mem());

--- a/c_src/ex_dtls/dtls.h
+++ b/c_src/ex_dtls/dtls.h
@@ -10,6 +10,9 @@
 
 #include "log.h"
 
+#define MODE_CLIENT 0
+#define MODE_SERVER 1
+
 typedef struct KeyingMaterial {
   unsigned char *client; // client keying material - master key + master salt
   unsigned char *server;

--- a/c_src/ex_dtls/dtls.h
+++ b/c_src/ex_dtls/dtls.h
@@ -6,6 +6,7 @@
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <string.h>
+#include <sys/time.h>
 
 #include "log.h"
 
@@ -23,3 +24,4 @@ EVP_PKEY *gen_key();
 X509 *gen_cert(EVP_PKEY *pkey);
 EVP_PKEY *decode_pkey(unsigned char *buf, int len);
 X509 *decode_cert(unsigned char *buf, int len);
+int get_timeout(SSL *ssl);

--- a/c_src/ex_dtls/dtls.h
+++ b/c_src/ex_dtls/dtls.h
@@ -21,7 +21,7 @@ typedef struct KeyingMaterial {
 } KeyingMaterial;
 
 SSL_CTX *create_ctx(int dtls_srtp);
-SSL *create_ssl(SSL_CTX *ssl_ctx, int client_mode);
+SSL *create_ssl(SSL_CTX *ssl_ctx, int mode);
 KeyingMaterial *export_keying_material(SSL *ssl);
 EVP_PKEY *gen_key();
 X509 *gen_cert(EVP_PKEY *pkey);

--- a/c_src/ex_dtls/native.c
+++ b/c_src/ex_dtls/native.c
@@ -1,32 +1,28 @@
 #include <stdio.h>
 #include <sys/socket.h>
-#include <sys/time.h>
 #include <sys/un.h>
 #include <unistd.h>
 
 #include "dyn_buff.h"
 #include "native.h"
 
-void ssl_info_cb(const SSL *ssl, int where, int ret);
-int read_pending_data(UnifexPayload *gen_packets, int pending_data_len,
-                      State *state);
+static void ssl_info_cb(const SSL *ssl, int where, int ret);
+static int verify_cb(int preverify_ok, X509_STORE_CTX *ctx);
+static int read_pending_data(UnifexPayload *gen_packets, int pending_data_len,
+                             State *state);
+static void cert_to_payload(UnifexEnv *env, X509 *x509, UnifexPayload *payload);
+static void pkey_to_payload(UnifexEnv *env, EVP_PKEY *pkey,
+                            UnifexPayload *payload);
+
 UNIFEX_TERM do_init(UnifexEnv *env, int client_mode, int dtls_srtp,
-                    EVP_PKEY *pkey, X509 *x509);
+                    int verify_peer, EVP_PKEY *pkey, X509 *x509);
 UNIFEX_TERM handle_regular_read(State *state, char data[], int ret);
 UNIFEX_TERM handle_read_error(State *state, int ret);
 UNIFEX_TERM handle_handshake_in_progress(State *state, int ret);
 UNIFEX_TERM handle_handshake_finished(State *state);
 
-static int get_timeout(State *state) {
-  struct timeval timeout;
-  int timeout_ms = 0;
-  if (DTLSv1_get_timeout(state->ssl, &timeout) == 1) {
-    timeout_ms = (timeout.tv_sec) * 1000 + (timeout.tv_usec / 1000);
-  }
-  return timeout_ms;
-}
-
-UNIFEX_TERM init(UnifexEnv *env, int client_mode, int dtls_srtp) {
+UNIFEX_TERM init(UnifexEnv *env, int client_mode, int dtls_srtp,
+                 int verify_peer) {
   UNIFEX_TERM res_term;
 
   EVP_PKEY *pkey = gen_key();
@@ -41,13 +37,14 @@ UNIFEX_TERM init(UnifexEnv *env, int client_mode, int dtls_srtp) {
     goto exit;
   }
 
-  res_term = do_init(env, client_mode, dtls_srtp, pkey, x509);
+  res_term = do_init(env, client_mode, dtls_srtp, verify_peer, pkey, x509);
 exit:
   return res_term;
 }
 
 UNIFEX_TERM init_from_key_cert(UnifexEnv *env, int client_mode, int dtls_srtp,
-                               UnifexPayload *pkey, UnifexPayload *cert) {
+                               int verify_peer, UnifexPayload *pkey,
+                               UnifexPayload *cert) {
   UNIFEX_TERM res_term;
 
   EVP_PKEY *evp_pkey = decode_pkey(pkey->data, pkey->size);
@@ -62,13 +59,13 @@ UNIFEX_TERM init_from_key_cert(UnifexEnv *env, int client_mode, int dtls_srtp,
     goto exit;
   }
 
-  res_term = do_init(env, client_mode, dtls_srtp, evp_pkey, x509);
+  res_term = do_init(env, client_mode, dtls_srtp, verify_peer, evp_pkey, x509);
 exit:
   return res_term;
 }
 
 UNIFEX_TERM do_init(UnifexEnv *env, int client_mode, int dtls_srtp,
-                    EVP_PKEY *pkey, X509 *x509) {
+                    int verify_peer, EVP_PKEY *pkey, X509 *x509) {
   UNIFEX_TERM res_term;
   State *state = unifex_alloc_state(env);
   state->env = unifex_alloc_env(env);
@@ -77,6 +74,10 @@ UNIFEX_TERM do_init(UnifexEnv *env, int client_mode, int dtls_srtp,
   if (state->ssl_ctx == NULL) {
     res_term = unifex_raise(env, "Cannot create ssl_ctx");
     goto exit;
+  }
+
+  if (verify_peer == 1) {
+    SSL_CTX_set_verify(state->ssl_ctx, SSL_VERIFY_PEER, verify_cb);
   }
 
   state->pkey = pkey;
@@ -107,74 +108,77 @@ exit:
   return res_term;
 }
 
-void ssl_info_cb(const SSL *ssl, int where, int ret) {
-  (void)ssl;
-  (void)ret;
-  if (where & SSL_CB_ALERT) {
-    DEBUG("DTLS alert occurred.");
-  }
-}
-
-UNIFEX_TERM generate_cert(UnifexEnv *env) {
-  int len;
-  unsigned char *p;
+UNIFEX_TERM generate_key_cert(UnifexEnv *env) {
+  UnifexPayload pkey_payload;
+  UnifexPayload cert_payload;
 
   EVP_PKEY *pkey = gen_key();
   X509 *cert = gen_cert(pkey);
 
-  len = i2d_X509(cert, NULL);
-  UnifexPayload payload;
-  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, len, &payload);
-  p = payload.data;
-  i2d_X509(cert, &p);
-  payload.size = len;
-  UNIFEX_TERM res_term = generate_cert_result(env, &payload);
-  unifex_payload_release(&payload);
+  pkey_to_payload(env, pkey, &pkey_payload);
+  cert_to_payload(env, cert, &cert_payload);
+
+  UNIFEX_TERM res_term =
+      generate_key_cert_result(env, &pkey_payload, &cert_payload);
+  unifex_payload_release(&pkey_payload);
+  unifex_payload_release(&cert_payload);
   return res_term;
 }
 
 UNIFEX_TERM get_pkey(UnifexEnv *env, State *state) {
-  int len;
-  unsigned char *p;
-
-  len = i2d_PrivateKey(state->pkey, NULL);
   UnifexPayload payload;
-  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, len, &payload);
-  p = payload.data;
-  i2d_PrivateKey(state->pkey, &p);
-  payload.size = len;
+  pkey_to_payload(env, state->pkey, &payload);
   UNIFEX_TERM res_term = get_pkey_result(env, &payload);
   unifex_payload_release(&payload);
   return res_term;
 }
 
 UNIFEX_TERM get_cert(UnifexEnv *env, State *state) {
-  int len;
-  unsigned char *p;
-
-  len = i2d_X509(state->x509, NULL);
   UnifexPayload payload;
-  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, len, &payload);
-  p = payload.data;
-  i2d_X509(state->x509, &p);
-  payload.size = len;
+  cert_to_payload(env, state->x509, &payload);
   UNIFEX_TERM res_term = get_cert_result(env, &payload);
   unifex_payload_release(&payload);
   return res_term;
 }
 
-UNIFEX_TERM get_cert_fingerprint(UnifexEnv *env, State *state) {
+UNIFEX_TERM get_peer_cert(UnifexEnv *env, State *state) {
+  UNIFEX_TERM res_term;
+
+  X509 *x509 = SSL_get0_peer_certificate(state->ssl);
+
+  if (x509 != NULL) {
+    UnifexPayload payload;
+    cert_to_payload(env, x509, &payload);
+    res_term = get_peer_cert_result(env, &payload);
+    unifex_payload_release(&payload);
+  } else {
+    res_term = get_peer_cert_result_(env);
+  }
+
+  return res_term;
+}
+
+UNIFEX_TERM get_cert_fingerprint(UnifexEnv *env, UnifexPayload *cert) {
+  UNIFEX_TERM res_term;
   unsigned char md[EVP_MAX_MD_SIZE] = {0};
   unsigned int size;
-  if (X509_digest(state->x509, EVP_sha256(), md, &size) != 1) {
+
+  X509 *x509 = decode_cert(cert->data, cert->size);
+  if (x509 == NULL) {
+    res_term = unifex_raise(env, "Cannot decode cert");
+    goto exit;
+  }
+
+  if (X509_digest(x509, EVP_sha256(), md, &size) != 1) {
     return unifex_raise(env, "Can't get cert fingerprint");
   }
   UnifexPayload payload;
   unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, size, &payload);
   memcpy(payload.data, md, size);
   payload.size = size;
-  UNIFEX_TERM res_term = get_cert_fingerprint_result(env, &payload);
+  res_term = get_cert_fingerprint_result(env, &payload);
   unifex_payload_release(&payload);
+exit:
   return res_term;
 }
 
@@ -199,9 +203,8 @@ UNIFEX_TERM do_handshake(UnifexEnv *env, State *state) {
                            &gen_packets);
       memcpy(gen_packets.data, pending_data, pending_data_len);
       gen_packets.size = (unsigned int)pending_data_len;
-      int timeout = get_timeout(state);
-      UNIFEX_TERM res_term =
-          do_handshake_result(env, &gen_packets, timeout);
+      int timeout = get_timeout(state->ssl);
+      UNIFEX_TERM res_term = do_handshake_result(env, &gen_packets, timeout);
       unifex_payload_release(&gen_packets);
       return res_term;
     }
@@ -259,7 +262,8 @@ UNIFEX_TERM handle_read_error(State *state, int ret) {
   int error = SSL_get_error(state->ssl, ret);
   switch (error) {
   case SSL_ERROR_ZERO_RETURN:
-    return handle_data_result_connection_closed_peer_closed_for_writing(state->env);
+    return handle_data_result_connection_closed_peer_closed_for_writing(
+        state->env);
   case SSL_ERROR_WANT_READ:
     DEBUG("SSL WANT READ. This is workaround. Did we get retransmission?");
     return handle_data_result_handshake_want_read(state->env);
@@ -342,7 +346,7 @@ UNIFEX_TERM handle_handshake_in_progress(State *state, int ret) {
       if (read_pending_data(&gen_packets, pending_data_len, state) < 0) {
         return unifex_raise(state->env, "Handshake failed: write BIO error");
       }
-      int timeout = get_timeout(state);
+      int timeout = get_timeout(state->ssl);
       UNIFEX_TERM res_term = handle_data_result_handshake_packets(
           state->env, &gen_packets, timeout);
       unifex_payload_release(&gen_packets);
@@ -370,7 +374,7 @@ UNIFEX_TERM handle_timeout(UnifexEnv *env, State *state) {
     return unifex_raise(state->env,
                         "Retransmit handshake failed: write BIO error");
   } else {
-    int timeout = get_timeout(state);
+    int timeout = get_timeout(state->ssl);
     UNIFEX_TERM res_term =
         handle_timeout_result_retransmit(env, &gen_packets, timeout);
     unifex_payload_release(&gen_packets);
@@ -378,8 +382,24 @@ UNIFEX_TERM handle_timeout(UnifexEnv *env, State *state) {
   }
 }
 
-int read_pending_data(UnifexPayload *gen_packets, int pending_data_len,
-                      State *state) {
+static void ssl_info_cb(const SSL *ssl, int where, int ret) {
+  UNIFEX_UNUSED(ssl);
+  UNIFEX_UNUSED(ret);
+  if (where & SSL_CB_ALERT) {
+    DEBUG("DTLS alert occurred.");
+  }
+}
+
+static int verify_cb(int preverify_ok, X509_STORE_CTX *ctx) {
+  // TODO implement this callback
+  UNIFEX_UNUSED(preverify_ok);
+  UNIFEX_UNUSED(ctx);
+  DEBUG("Verify callback, preverify_ok: %d", preverify_ok);
+  return 1;
+}
+
+static int read_pending_data(UnifexPayload *gen_packets, int pending_data_len,
+                             State *state) {
   char *pending_data = (char *)malloc(pending_data_len * sizeof(char));
   memset(pending_data, 0, pending_data_len);
   BIO *wbio = SSL_get_wbio(state->ssl);
@@ -394,6 +414,24 @@ int read_pending_data(UnifexPayload *gen_packets, int pending_data_len,
   free(pending_data);
 
   return read_bytes;
+}
+
+static void cert_to_payload(UnifexEnv *env, X509 *x509,
+                            UnifexPayload *payload) {
+  int len = i2d_X509(x509, NULL);
+  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, len, payload);
+  unsigned char *p = payload->data;
+  i2d_X509(x509, &p);
+  payload->size = len;
+}
+
+static void pkey_to_payload(UnifexEnv *env, EVP_PKEY *pkey,
+                            UnifexPayload *payload) {
+  int len = i2d_PrivateKey(pkey, NULL);
+  unifex_payload_alloc(env, UNIFEX_PAYLOAD_BINARY, len, payload);
+  unsigned char *p = payload->data;
+  i2d_PrivateKey(pkey, &p);
+  payload->size = len;
 }
 
 void handle_destroy_state(UnifexEnv *env, State *state) {

--- a/c_src/ex_dtls/native.h
+++ b/c_src/ex_dtls/native.h
@@ -11,7 +11,7 @@ struct State {
   SSL *ssl;
   EVP_PKEY *pkey;
   X509 *x509;
-  int client_mode;
+  int mode;
   int hsk_finished;
 };
 

--- a/c_src/ex_dtls/native.spec.exs
+++ b/c_src/ex_dtls/native.spec.exs
@@ -4,9 +4,9 @@ interface NIF
 
 state_type "State"
 
-spec init(client_mode :: bool, dtls_srtp :: bool, verify_peer :: bool) :: state
+spec init(mode :: atom, dtls_srtp :: bool, verify_peer :: bool) :: state
 
-spec init_from_key_cert(client_mode :: bool, dtls_srtp :: bool, verify_peer :: bool, pkey :: payload, cert :: payload) ::
+spec init_from_key_cert(mode :: atom, dtls_srtp :: bool, verify_peer :: bool, pkey :: payload, cert :: payload) ::
        state
 
 spec generate_key_cert() :: {pkey :: payload, cert :: payload}

--- a/c_src/ex_dtls/native.spec.exs
+++ b/c_src/ex_dtls/native.spec.exs
@@ -4,18 +4,20 @@ interface NIF
 
 state_type "State"
 
-spec init(client_mode :: bool, dtls_srtp :: bool) :: state
+spec init(client_mode :: bool, dtls_srtp :: bool, verify_peer :: bool) :: state
 
-spec init_from_key_cert(client_mode :: bool, dtls_srtp :: bool, pkey :: payload, cert :: payload) ::
+spec init_from_key_cert(client_mode :: bool, dtls_srtp :: bool, verify_peer :: bool, pkey :: payload, cert :: payload) ::
        state
 
-spec generate_cert() :: cert :: payload
+spec generate_key_cert() :: {pkey :: payload, cert :: payload}
 
-spec get_pkey(state) :: pkey :: payload
+spec get_pkey(state) :: payload
 
-spec get_cert(state) :: cert :: payload
+spec get_cert(state) :: payload
 
-spec get_cert_fingerprint(state) :: fingerprint :: payload
+spec get_peer_cert(state) :: payload | (nil :: label)
+
+spec get_cert_fingerprint(payload) :: payload
 
 spec do_handshake(state) :: {packets :: payload, timeout :: int}
 

--- a/lib/ex_dtls.ex
+++ b/lib/ex_dtls.ex
@@ -15,10 +15,11 @@ defmodule ExDTLS do
   See `init/1` for the meaning of each option
   """
   @type opts_t :: [
-          client_mode: boolean(),
+          mode: :client | :server,
           dtls_srtp: boolean(),
           pkey: binary(),
-          cert: binary()
+          cert: binary(),
+          verify_peer: boolean()
         ]
 
   @typedoc """
@@ -38,7 +39,7 @@ defmodule ExDTLS do
   Initializes `ExDTLS`.
 
   Accepts a keyword list with the following options (`t:opts_t/0`):
-  * `client_mode` - `true` if ExDTLS module should work as a client or `false` if as a server.
+  * `mode` - `:client` if ExDTLS module should work as a client or `:server` if as a server.
   This option is required.
   * `dtls_srtp` - `true` if DTLS-SRTP handshake should be performed or `false` if a normal one.
   Defaults to `false`.
@@ -53,15 +54,15 @@ defmodule ExDTLS do
   @spec init(opts :: opts_t) :: dtls()
   def init(opts) do
     srtp = Keyword.get(opts, :dtls_srtp, false)
-    client = Keyword.fetch!(opts, :client_mode)
+    mode = Keyword.fetch!(opts, :mode)
     verify_peer = Keyword.get(opts, :verify_peer, true)
 
     cond do
       opts[:pkey] == nil and opts[:cert] == nil ->
-        Native.init(client, srtp, verify_peer)
+        Native.init(mode, srtp, verify_peer)
 
       opts[:pkey] != nil and opts[:cert] != nil ->
-        Native.init_from_key_cert(client, srtp, verify_peer, opts[:pkey], opts[:cert])
+        Native.init_from_key_cert(mode, srtp, verify_peer, opts[:pkey], opts[:cert])
 
       true ->
         raise ArgumentError, """

--- a/lib/ex_dtls.ex
+++ b/lib/ex_dtls.ex
@@ -38,24 +38,30 @@ defmodule ExDTLS do
   Initializes `ExDTLS`.
 
   Accepts a keyword list with the following options (`t:opts_t/0`):
-  * `client_mode` - `true` if ExDTLS module should work as a client or `false` if as a server
-  * `dtls_srtp` - `true` if DTLS-SRTP handshake should be performed or `false` if a normal one
-  * `pkey` - private key to use in this SSL context. Must correspond to `cert`
-  * `cert` - certificate to use in this SSL context. Must correspond to `pkey`
-
+  * `client_mode` - `true` if ExDTLS module should work as a client or `false` if as a server.
+  This option is required.
+  * `dtls_srtp` - `true` if DTLS-SRTP handshake should be performed or `false` if a normal one.
+  Defaults to `false`.
+  * `pkey` - private key to use in this SSL context. Must correspond to `cert`.
   If both `pkey` and `cert` are not passed `ExDTLS` will generate key and certificate on its own.
+  * `cert` - certificate to use in this SSL context. Must correspond to `pkey`.
+  If both `pkey` and `cert` are not passed `ExDTLS` will generate key and certificate on its own.
+  * `verify_peer` - `true` if peer's certificate should be verified.
+  Note that if `verify_peer` is `false`, `get_peer_cert/1` called on `ExDTLS` working in the
+  server mode, will always return `nil`. Defaults to `true`.
   """
   @spec init(opts :: opts_t) :: dtls()
   def init(opts) do
-    srtp? = Keyword.get(opts, :dtls_srtp, false)
-    client? = Keyword.fetch!(opts, :client_mode)
+    srtp = Keyword.get(opts, :dtls_srtp, false)
+    client = Keyword.fetch!(opts, :client_mode)
+    verify_peer = Keyword.get(opts, :verify_peer, true)
 
     cond do
       opts[:pkey] == nil and opts[:cert] == nil ->
-        Native.init(client?, srtp?)
+        Native.init(client, srtp, verify_peer)
 
       opts[:pkey] != nil and opts[:cert] != nil ->
-        Native.init_from_key_cert(client?, srtp?, opts[:pkey], opts[:cert])
+        Native.init_from_key_cert(client, srtp, verify_peer, opts[:pkey], opts[:cert])
 
       true ->
         raise ArgumentError, """
@@ -66,15 +72,15 @@ defmodule ExDTLS do
   end
 
   @doc """
-  Generates new certificate.
+  Generates a new key/certificate pair.
 
   Returns DER representation in binary format.
   """
-  @spec generate_cert() :: binary()
-  defdelegate generate_cert(), to: Native
+  @spec generate_key_cert() :: {pkey :: binary(), cert :: binary()}
+  defdelegate generate_key_cert(), to: Native
 
   @doc """
-  Gets current private key.
+  Gets current, local private key.
 
   Returns key specific representation in binary format.
   """
@@ -82,7 +88,7 @@ defmodule ExDTLS do
   defdelegate get_pkey(dtls), to: Native
 
   @doc """
-  Gets current certificate.
+  Gets current, local certificate.
 
   Returns DER representation in binary format.
   """
@@ -90,10 +96,27 @@ defmodule ExDTLS do
   defdelegate get_cert(dtls), to: Native
 
   @doc """
+  Gets peer certificate.
+
+  Returns DER representation in binary format or `nil` 
+  when no certificate was presented by the peer or no connection
+  was established.
+  """
+  @spec get_peer_cert(dtls()) :: binary() | nil
+  def get_peer_cert(dtls) do
+    case Native.get_peer_cert(dtls) do
+      # Unifex can't return nil
+      # see https://github.com/membraneframework/membrane_core/issues/684
+      :"" -> nil
+      other -> other
+    end
+  end
+
+  @doc """
   Returns a digest of the DER representation of the X509 certificate.
   """
-  @spec get_cert_fingerprint(dtls()) :: binary
-  defdelegate get_cert_fingerprint(dtls), to: Native
+  @spec get_cert_fingerprint(binary()) :: binary()
+  defdelegate get_cert_fingerprint(cert), to: Native
 
   @doc """
   Starts performing DTLS handshake.

--- a/test/ex_dtls_test.exs
+++ b/test/ex_dtls_test.exs
@@ -16,8 +16,8 @@ defmodule ExDTLSTest do
   end
 
   test "cert fingerprint" do
-    dtls = ExDTLS.init(client_mode: false, dtls_srtp: false)
-    fingerprint = ExDTLS.get_cert_fingerprint(dtls)
+    assert {_pkey, cert} = ExDTLS.generate_key_cert()
+    fingerprint = ExDTLS.get_cert_fingerprint(cert)
     assert byte_size(fingerprint) == 32
   end
 
@@ -32,8 +32,16 @@ defmodule ExDTLSTest do
   end
 
   test "generate cert" do
-    assert cert = ExDTLS.generate_cert()
+    assert {pkey, cert} = ExDTLS.generate_key_cert()
+    assert pkey != <<>>
     assert cert != <<>>
+    assert is_binary(pkey) == true
     assert is_binary(cert) == true
+  end
+
+  test "get peer cert" do
+    dtls = ExDTLS.init(client_mode: false, dtls_srtp: false)
+    # before finishing handshake, there should be no peer cert
+    assert nil == ExDTLS.get_peer_cert(dtls)
   end
 end

--- a/test/ex_dtls_test.exs
+++ b/test/ex_dtls_test.exs
@@ -2,14 +2,14 @@ defmodule ExDTLSTest do
   use ExUnit.Case, async: true
 
   test "start with custom cert" do
-    dtls = ExDTLS.init(client_mode: false, dtls_srtp: false)
+    dtls = ExDTLS.init(mode: :server, dtls_srtp: false)
 
     pkey = ExDTLS.get_pkey(dtls)
     cert = ExDTLS.get_cert(dtls)
 
-    assert dtls2 = ExDTLS.init(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
+    assert dtls2 = ExDTLS.init(mode: :server, dtls_srtp: false, pkey: pkey, cert: cert)
 
-    assert dtls3 = ExDTLS.init(client_mode: false, dtls_srtp: false, pkey: pkey, cert: cert)
+    assert dtls3 = ExDTLS.init(mode: :server, dtls_srtp: false, pkey: pkey, cert: cert)
 
     assert ExDTLS.get_pkey(dtls2) == ExDTLS.get_pkey(dtls3)
     assert ExDTLS.get_pkey(dtls2) == ExDTLS.get_pkey(dtls3)
@@ -22,12 +22,12 @@ defmodule ExDTLSTest do
   end
 
   test "get pkey" do
-    dtls = ExDTLS.init(client_mode: false, dtls_srtp: false)
+    dtls = ExDTLS.init(mode: :server, dtls_srtp: false)
     assert _pkey = ExDTLS.get_pkey(dtls)
   end
 
   test "get cert" do
-    dtls = ExDTLS.init(client_mode: false, dtls_srtp: false)
+    dtls = ExDTLS.init(mode: :server, dtls_srtp: false)
     assert _cert = ExDTLS.get_cert(dtls)
   end
 
@@ -40,7 +40,7 @@ defmodule ExDTLSTest do
   end
 
   test "get peer cert" do
-    dtls = ExDTLS.init(client_mode: false, dtls_srtp: false)
+    dtls = ExDTLS.init(mode: :server, dtls_srtp: false)
     # before finishing handshake, there should be no peer cert
     assert nil == ExDTLS.get_peer_cert(dtls)
   end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -4,8 +4,27 @@ defmodule ExDTLS.IntegrationTest do
   test "dtls_srtp" do
     rx_dtls = ExDTLS.init(client_mode: false, dtls_srtp: true)
     tx_dtls = ExDTLS.init(client_mode: true, dtls_srtp: true)
+
     {packets, _timeout} = ExDTLS.do_handshake(tx_dtls)
+
     assert :ok == loop({rx_dtls, false}, {tx_dtls, false}, packets)
+
+    assert ExDTLS.get_peer_cert(tx_dtls) == ExDTLS.get_cert(rx_dtls)
+    assert ExDTLS.get_peer_cert(rx_dtls) == ExDTLS.get_cert(tx_dtls)
+  end
+
+  test "dtls_srtp with no verify_peer" do
+    rx_dtls = ExDTLS.init(client_mode: false, dtls_srtp: true, verify_peer: false)
+    tx_dtls = ExDTLS.init(client_mode: true, dtls_srtp: true)
+
+    {packets, _timeout} = ExDTLS.do_handshake(tx_dtls)
+
+    assert :ok == loop({rx_dtls, false}, {tx_dtls, false}, packets)
+
+    assert ExDTLS.get_peer_cert(tx_dtls) == ExDTLS.get_cert(rx_dtls)
+    # Client only sends its certificate when requested to do so by the server.
+    # Because `verify_peer` is set to `false`, server won't ask for the client's certificate. 
+    assert ExDTLS.get_peer_cert(rx_dtls) == nil
   end
 
   defp loop({_dtls1, true}, {_dtls2, true}, _packets) do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -2,8 +2,8 @@ defmodule ExDTLS.IntegrationTest do
   use ExUnit.Case, async: true
 
   test "dtls_srtp" do
-    rx_dtls = ExDTLS.init(client_mode: false, dtls_srtp: true)
-    tx_dtls = ExDTLS.init(client_mode: true, dtls_srtp: true)
+    rx_dtls = ExDTLS.init(mode: :server, dtls_srtp: true)
+    tx_dtls = ExDTLS.init(mode: :client, dtls_srtp: true)
 
     {packets, _timeout} = ExDTLS.do_handshake(tx_dtls)
 
@@ -14,8 +14,8 @@ defmodule ExDTLS.IntegrationTest do
   end
 
   test "dtls_srtp with no verify_peer" do
-    rx_dtls = ExDTLS.init(client_mode: false, dtls_srtp: true, verify_peer: false)
-    tx_dtls = ExDTLS.init(client_mode: true, dtls_srtp: true)
+    rx_dtls = ExDTLS.init(mode: :server, dtls_srtp: true, verify_peer: false)
+    tx_dtls = ExDTLS.init(mode: :client, dtls_srtp: true)
 
     {packets, _timeout} = ExDTLS.do_handshake(tx_dtls)
 

--- a/test/retransmission_test.exs
+++ b/test/retransmission_test.exs
@@ -2,8 +2,8 @@ defmodule ExDTLS.RetransmissionTest do
   use ExUnit.Case, async: true
 
   test "retransmission" do
-    rx_dtls = ExDTLS.init(client_mode: false, dtls_srtp: true)
-    tx_dtls = ExDTLS.init(client_mode: true, dtls_srtp: true)
+    rx_dtls = ExDTLS.init(mode: :server, dtls_srtp: true)
+    tx_dtls = ExDTLS.init(mode: :client, dtls_srtp: true)
 
     {_packets, timeout} = ExDTLS.do_handshake(tx_dtls)
     Process.send_after(self(), {:handle_timeout, :tx}, timeout)


### PR DESCRIPTION
* `generate_cert` renamed to `generate_pkey_cert` as it also returns pkey. It also no longer requires native reference as an argument
* `get_cert_fingerprint` no longer requires native reference as an argument
* added verify_peer option (not fully implemented)