### PR TITLE
Add support for DTLS fragmentation

### DIFF
--- a/bundlex.exs
+++ b/bundlex.exs
@@ -15,7 +15,7 @@ defmodule ExDTLS.BundlexProject do
         os_deps: [openssl: :pkg_config],
         libs: ["pthread"],
         interface: [:nif],
-        compiler_flags: ["-DEXDTLS_DEBUG"],
+        # compiler_flags: ["-DEXDTLS_DEBUG"],
         preprocessor: Unifex
       ]
     ]

--- a/bundlex.exs
+++ b/bundlex.exs
@@ -10,12 +10,12 @@ defmodule ExDTLS.BundlexProject do
   defp natives() do
     [
       native: [
-        sources: ["native.c", "dtls.c", "dyn_buff.c"],
+        sources: ["native.c", "dtls.c", "dyn_buff.c", "bio_frag.c"],
         deps: [unifex: :unifex],
         os_deps: [openssl: :pkg_config],
         libs: ["pthread"],
         interface: [:nif],
-        # compiler_flags: ["-DEXDTLS_DEBUG"],
+        compiler_flags: ["-DEXDTLS_DEBUG"],
         preprocessor: Unifex
       ]
     ]

--- a/c_src/ex_dtls/bio_frag.c
+++ b/c_src/ex_dtls/bio_frag.c
@@ -12,6 +12,7 @@ static long callback_ctrl(BIO *bio, int cmd, BIO_info_cb *fp);
 static BIO_METHOD *bio_methods = NULL;
 
 #define MAX_FRAGS 100
+#define MTU 1200
 
 struct Ctx {
   int frag_sizes[MAX_FRAGS];
@@ -124,6 +125,8 @@ static long ctrl(BIO *bio, int cmd, long num, void *ptr) {
 
   if (cmd == BIO_CTRL_PENDING) {
     return ctx->frag_sizes[ctx->riter];
+  } else if (cmd == BIO_CTRL_DGRAM_QUERY_MTU) {
+    return MTU;
   }
 
   return BIO_ctrl(next, cmd, num, ptr);

--- a/c_src/ex_dtls/bio_frag.c
+++ b/c_src/ex_dtls/bio_frag.c
@@ -1,0 +1,98 @@
+
+#include "bio_frag.h"
+
+static int bwrite(BIO *bio, const char *buf, int len);
+static int bread(BIO *bio, char *buf, int len);
+static long ctrl(BIO *bio, int cmd, long arg1, void *arg2);
+static int create(BIO *bio);
+static int destroy(BIO *bio);
+static long callback_ctrl(BIO *bio, int cmd, BIO_info_cb *fp);
+
+// static const BIO_METHOD bio_methods = {
+//   BIO_TYPE_BIO,
+//   "DTLS fragmentation for mem BIO",
+//   bwrite_conv,
+//   bwrite,
+//   bread_conv,
+//   bread,
+//   NULL,
+//   NULL,
+//   ctrl,
+//   create,
+//   destroy,
+//   callback_ctrl
+// };
+
+static BIO_METHOD *bio_methods = NULL;
+
+const BIO_METHOD *BIO_f_frag(void) {
+  bio_methods = BIO_meth_new(BIO_TYPE_FILTER, "DTLS fragmentation for mem BIO");
+
+  BIO_meth_set_read(bio_methods, bread);
+  BIO_meth_set_write(bio_methods, bwrite);
+  BIO_meth_set_ctrl(bio_methods, ctrl);
+  BIO_meth_set_create(bio_methods, create);
+  BIO_meth_set_destroy(bio_methods, destroy);
+  BIO_meth_set_callback_ctrl(bio_methods, callback_ctrl);
+
+  return bio_methods;
+}
+
+static int create(BIO *bio) {
+  DEBUG("BIO frag create");
+  // indicate that BIO initialization is complete 
+  BIO_set_init(bio, 1);
+  return 1;
+}
+
+static int destroy(BIO *bio) {
+  DEBUG("BIO frag destroy");
+  if (bio == NULL) {
+    return 0;
+  }
+
+  BIO_set_init(bio, 0);
+  return 1;
+}
+
+static int bread(BIO *bio, char *buf, int len) {
+  DEBUG("BIO frag bread");
+  BIO *next = BIO_next(bio);
+  if (next == NULL) {
+    return 0;
+  }
+
+  return BIO_read(next, buf, len);
+}
+
+static int bwrite(BIO *bio, const char *buf, int len) {
+  DEBUG("BIO frag bwrite %d", len);
+  BIO *next = BIO_next(bio);
+  if (next == NULL) {
+    return 0;
+  }
+
+  return BIO_write(next, buf, len);
+}
+
+static long ctrl(BIO *bio, int cmd, long num, void *ptr) {
+  DEBUG("BIO frag ctrl");
+
+  BIO *next = BIO_next(bio);
+  if (next == NULL) {
+    return 0;
+  }
+
+  return BIO_ctrl(next, cmd, num, ptr);
+}
+
+static long callback_ctrl(BIO *bio, int cmd, BIO_info_cb *fp) {
+  BIO *next = BIO_next(bio);
+  if (next == NULL) {
+    return 0;
+  }
+
+  return BIO_callback_ctrl(next, cmd, fp);
+}
+
+

--- a/c_src/ex_dtls/bio_frag.c
+++ b/c_src/ex_dtls/bio_frag.c
@@ -1,5 +1,6 @@
 
 #include "bio_frag.h"
+#include <openssl/bio.h>
 
 static int bwrite(BIO *bio, const char *buf, int len);
 static int bread(BIO *bio, char *buf, int len);
@@ -8,22 +9,15 @@ static int create(BIO *bio);
 static int destroy(BIO *bio);
 static long callback_ctrl(BIO *bio, int cmd, BIO_info_cb *fp);
 
-// static const BIO_METHOD bio_methods = {
-//   BIO_TYPE_BIO,
-//   "DTLS fragmentation for mem BIO",
-//   bwrite_conv,
-//   bwrite,
-//   bread_conv,
-//   bread,
-//   NULL,
-//   NULL,
-//   ctrl,
-//   create,
-//   destroy,
-//   callback_ctrl
-// };
-
 static BIO_METHOD *bio_methods = NULL;
+
+#define MAX_FRAGS 100
+
+struct Ctx {
+  int frag_sizes[MAX_FRAGS];
+  int witer;
+  int riter;
+};
 
 const BIO_METHOD *BIO_f_frag(void) {
   bio_methods = BIO_meth_new(BIO_TYPE_FILTER, "DTLS fragmentation for mem BIO");
@@ -39,48 +33,97 @@ const BIO_METHOD *BIO_f_frag(void) {
 }
 
 static int create(BIO *bio) {
-  DEBUG("BIO frag create");
-  // indicate that BIO initialization is complete 
+  struct Ctx *ctx = calloc(1, sizeof(struct Ctx));
+  for (int i = 0; i < MAX_FRAGS; i++) {
+    ctx->frag_sizes[i] = 0;
+  }
+  ctx->witer = 0;
+  ctx->riter = 0;
+
+  BIO_set_data(bio, ctx);
   BIO_set_init(bio, 1);
   return 1;
 }
 
 static int destroy(BIO *bio) {
-  DEBUG("BIO frag destroy");
   if (bio == NULL) {
     return 0;
   }
 
+  struct Ctx *ctx = BIO_get_data(bio);
+  free(ctx);
+  BIO_set_data(bio, NULL);
   BIO_set_init(bio, 0);
   return 1;
 }
 
 static int bread(BIO *bio, char *buf, int len) {
-  DEBUG("BIO frag bread");
   BIO *next = BIO_next(bio);
   if (next == NULL) {
     return 0;
   }
 
-  return BIO_read(next, buf, len);
+  struct Ctx *ctx = BIO_get_data(bio);
+
+  if (len != ctx->frag_sizes[ctx->riter]) {
+    return 0;
+  }
+
+  int ret = BIO_read(next, buf, len);
+
+  if (ret > 0) {
+    if (ret == ctx->frag_sizes[ctx->riter]) {
+      ctx->frag_sizes[ctx->riter] = 0;
+      ctx->riter++;
+
+      if (ctx->riter == ctx->witer && ctx->frag_sizes[ctx->riter] == 0) {
+        // reset iterators
+        ctx->riter = 0;
+        ctx->witer = 0;
+      }
+
+    } else if (ret < ctx->frag_sizes[ctx->riter]) {
+      ctx->frag_sizes[ctx->riter] -= ret;
+    } else {
+      // This should never happen
+      return 0;
+    }
+  };
+
+  return ret;
 }
 
 static int bwrite(BIO *bio, const char *buf, int len) {
-  DEBUG("BIO frag bwrite %d", len);
   BIO *next = BIO_next(bio);
   if (next == NULL) {
     return 0;
   }
 
-  return BIO_write(next, buf, len);
+  struct Ctx *ctx = BIO_get_data(bio);
+
+  if (ctx->witer >= MAX_FRAGS) {
+    return 0;
+  }
+
+  int ret = BIO_write(next, buf, len);
+  if (ret > 0) {
+    ctx->frag_sizes[ctx->witer] = ret;
+    ctx->witer++;
+  }
+
+  return ret;
 }
 
 static long ctrl(BIO *bio, int cmd, long num, void *ptr) {
-  DEBUG("BIO frag ctrl");
-
   BIO *next = BIO_next(bio);
   if (next == NULL) {
     return 0;
+  }
+
+  struct Ctx *ctx = BIO_get_data(bio);
+
+  if (cmd == BIO_CTRL_PENDING) {
+    return ctx->frag_sizes[ctx->riter];
   }
 
   return BIO_ctrl(next, cmd, num, ptr);
@@ -94,5 +137,3 @@ static long callback_ctrl(BIO *bio, int cmd, BIO_info_cb *fp) {
 
   return BIO_callback_ctrl(next, cmd, fp);
 }
-
-

--- a/c_src/ex_dtls/bio_frag.h
+++ b/c_src/ex_dtls/bio_frag.h
@@ -1,0 +1,7 @@
+#include <openssl/opensslv.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
+#include "log.h"
+
+const BIO_METHOD *BIO_f_frag(void);

--- a/c_src/ex_dtls/dtls.c
+++ b/c_src/ex_dtls/dtls.c
@@ -35,19 +35,19 @@ SSL *create_ssl(SSL_CTX *ssl_ctx, int mode) {
     return NULL;
   }
 
-  // BIO *frag_bio = BIO_new(BIO_f_frag());
-  // if (frag_bio == NULL) {
-  //   DEBUG("Cannot create frag bio");
-  //   return NULL;
-  // }
+  BIO *frag_bio = BIO_new(BIO_f_frag());
+  if (frag_bio == NULL) {
+    DEBUG("Cannot create frag bio");
+    return NULL;
+  }
 
-  // BIO *wmem_bio = BIO_new(BIO_s_mem());
-  // if (wmem_bio == NULL) {
-  //   DEBUG("Cannot create write mem bio");
-  //   return NULL;
-  // }
+  BIO *wmem_bio = BIO_new(BIO_s_mem());
+  if (wmem_bio == NULL) {
+    DEBUG("Cannot create write mem bio");
+    return NULL;
+  }
 
-  // BIO *wchain = BIO_push(frag_bio, wmem_bio);
+  BIO *wchain = BIO_push(frag_bio, wmem_bio);
 
   BIO *rmem_bio = BIO_new(BIO_s_mem());
   if (rmem_bio == NULL) {
@@ -55,26 +55,22 @@ SSL *create_ssl(SSL_CTX *ssl_ctx, int mode) {
     return NULL;
   }
 
-  BIO *rbio = BIO_new(BIO_s_dgram_mem());
-  if (rbio == NULL) {
-    DEBUG("Cannot create read dgram mem bio");
-    return NULL;
-  }
-
-  BIO *wbio = BIO_new(BIO_s_dgram_mem());
-  if (wbio == NULL) {
-    DEBUG("Cannot create write dgram mem bio");
-    return NULL;
-  }
-
-  // SSL_set_bio(ssl, rmem_bio, wchain);
-  SSL_set_bio(ssl, rbio, wbio);
-  
-  // printf("Setting MTU to 1000\n");
-  // if (SSL_set_mtu(ssl, 1500) == 0) {
+  // #TODO Move to the BIO_s_dgram_mem once we require OpenSSL 3
+  // BIO *rbio = BIO_new(BIO_s_dgram_mem());
+  // if (rbio == NULL) {
+  //   DEBUG("Cannot create read dgram mem bio");
   //   return NULL;
-  // } 
-  
+  // }
+
+  // BIO *wbio = BIO_new(BIO_s_dgram_mem());
+  // if (wbio == NULL) {
+  //   DEBUG("Cannot create write dgram mem bio");
+  //   return NULL;
+  // }
+
+  SSL_set_bio(ssl, rmem_bio, wchain);
+  // SSL_set_bio(ssl, rbio, wbio);
+
   return ssl;
 }
 

--- a/c_src/ex_dtls/dtls.c
+++ b/c_src/ex_dtls/dtls.c
@@ -35,19 +35,19 @@ SSL *create_ssl(SSL_CTX *ssl_ctx, int mode) {
     return NULL;
   }
 
-  BIO *frag_bio = BIO_new(BIO_f_frag());
-  if (frag_bio == NULL) {
-    DEBUG("Cannot create frag bio");
-    return NULL;
-  }
+  // BIO *frag_bio = BIO_new(BIO_f_frag());
+  // if (frag_bio == NULL) {
+  //   DEBUG("Cannot create frag bio");
+  //   return NULL;
+  // }
 
-  BIO *wmem_bio = BIO_new(BIO_s_mem());
-  if (wmem_bio == NULL) {
-    DEBUG("Cannot create write mem bio");
-    return NULL;
-  }
+  // BIO *wmem_bio = BIO_new(BIO_s_mem());
+  // if (wmem_bio == NULL) {
+  //   DEBUG("Cannot create write mem bio");
+  //   return NULL;
+  // }
 
-  BIO *wchain = BIO_push(frag_bio, wmem_bio);
+  // BIO *wchain = BIO_push(frag_bio, wmem_bio);
 
   BIO *rmem_bio = BIO_new(BIO_s_mem());
   if (rmem_bio == NULL) {
@@ -55,14 +55,26 @@ SSL *create_ssl(SSL_CTX *ssl_ctx, int mode) {
     return NULL;
   }
 
-  SSL_set_bio(ssl, rmem_bio, wchain);
+  BIO *rbio = BIO_new(BIO_s_dgram_mem());
+  if (rbio == NULL) {
+    DEBUG("Cannot create read dgram mem bio");
+    return NULL;
+  }
+
+  BIO *wbio = BIO_new(BIO_s_dgram_mem());
+  if (wbio == NULL) {
+    DEBUG("Cannot create write dgram mem bio");
+    return NULL;
+  }
+
+  // SSL_set_bio(ssl, rmem_bio, wchain);
+  SSL_set_bio(ssl, rbio, wbio);
   
   // printf("Setting MTU to 1000\n");
   // if (SSL_set_mtu(ssl, 1500) == 0) {
   //   return NULL;
   // } 
   
-
   return ssl;
 }
 

--- a/c_src/ex_dtls/native.c
+++ b/c_src/ex_dtls/native.c
@@ -34,11 +34,6 @@ int handle_load(UnifexEnv *env, void **priv_data) {
   UNIFEX_UNUSED(env);
   UNIFEX_UNUSED(priv_data);
 
-  if (OPENSSL_VERSION_NUMBER < 0x30000000L) {
-    DEBUG("ExDTLS requires OpenSSL 3");
-    return -1;
-  }
-
   FILE *urandom = fopen("/dev/urandom", "r");
   if (urandom == NULL) {
     DEBUG("Cannot open /dev/urandom");

--- a/c_src/ex_dtls/native.c
+++ b/c_src/ex_dtls/native.c
@@ -331,13 +331,12 @@ UNIFEX_TERM handle_data(UnifexEnv *env, State *state, UnifexPayload *payload) {
 
 UNIFEX_TERM handle_regular_read(State *state, char data[], int ret) {
   if (ret > 0) {
-    UnifexPayload **packets = calloc(1, sizeof(UnifexPayload *));
-    packets[0] = calloc(1, sizeof(UnifexPayload));
-    unifex_payload_alloc(state->env, UNIFEX_PAYLOAD_BINARY, ret, packets[0]);
-    memcpy(packets[0]->data, data, ret);
-    packets[0]->size = (unsigned int)ret;
-    UNIFEX_TERM res_term = handle_data_result_ok(state->env, packets, 1);
-    free_payload_array(packets, 1);
+    UnifexPayload packets;
+    unifex_payload_alloc(state->env, UNIFEX_PAYLOAD_BINARY, ret, &packets);
+    memcpy(packets.data, data, ret);
+    packets.size = (unsigned int)ret;
+    UNIFEX_TERM res_term = handle_data_result_ok(state->env, &packets);
+    unifex_payload_release(&packets);
     return res_term;
   }
 

--- a/c_src/ex_dtls/native.spec.exs
+++ b/c_src/ex_dtls/native.spec.exs
@@ -28,7 +28,7 @@ spec handle_timeout(state) :: (:ok :: label) | {:retransmit :: label, packets ::
 spec write_data(state, packets :: payload) :: {:ok :: label, packets :: [payload]} | {:error :: label, :handshake_not_finished :: label}
 
 spec handle_data(state, packets :: payload) ::
-       {:ok :: label, packets :: [payload]}
+       {:ok :: label, packets :: payload}
        | (:handshake_want_read :: label)
        | {:handshake_packets :: label, packets :: [payload], timeout :: int}
        | {:handshake_finished :: label, client_keying_material :: payload,

--- a/c_src/ex_dtls/native.spec.exs
+++ b/c_src/ex_dtls/native.spec.exs
@@ -21,18 +21,18 @@ spec get_peer_cert(state) :: payload | (nil :: label)
 
 spec get_cert_fingerprint(payload) :: payload
 
-spec do_handshake(state) :: {packets :: payload, timeout :: int}
+spec do_handshake(state) :: {packets :: [payload], timeout :: int}
 
-spec handle_timeout(state) :: (:ok :: label) | {:retransmit :: label, packets :: payload, timeout :: int}
+spec handle_timeout(state) :: (:ok :: label) | {:retransmit :: label, packets :: [payload], timeout :: int}
 
-spec write_data(state, packets :: payload) :: {:ok :: label, packets :: payload} | {:error :: label, :handshake_not_finished :: label}
+spec write_data(state, packets :: payload) :: {:ok :: label, packets :: [payload]} | {:error :: label, :handshake_not_finished :: label}
 
 spec handle_data(state, packets :: payload) ::
-       {:ok :: label, packets :: payload}
+       {:ok :: label, packets :: [payload]}
        | (:handshake_want_read :: label)
-       | {:handshake_packets :: label, packets :: payload, timeout :: int}
+       | {:handshake_packets :: label, packets :: [payload], timeout :: int}
        | {:handshake_finished :: label, client_keying_material :: payload,
-          server_keying_material :: payload, protection_profile :: int, packets :: payload}
+          server_keying_material :: payload, protection_profile :: int, packets :: [payload]}
        | {:error :: label, :peer_closed_for_writing :: label}
        | {:error :: label, :handshake_error :: label
 }

--- a/lib/ex_dtls.ex
+++ b/lib/ex_dtls.ex
@@ -139,7 +139,7 @@ defmodule ExDTLS do
 
   `timeout` is a time in ms after which `handle_timeout/1` should be called.
   """
-  @spec do_handshake(dtls()) :: {packets :: binary(), timeout :: integer()}
+  @spec do_handshake(dtls()) :: {packets :: [binary()], timeout :: integer()}
   defdelegate do_handshake(dtls), to: Native
 
   @doc """
@@ -147,9 +147,9 @@ defmodule ExDTLS do
 
   Generates encrypted packets that need to be passed to the second host.
   """
-  @spec write_data(dtls(), packets :: binary()) ::
-          {:ok, packets :: binary()} | {:error, :handshake_not_finished}
-  defdelegate write_data(dtls, packets), to: Native
+  @spec write_data(dtls(), data :: binary()) ::
+          {:ok, packets :: [binary()]} | {:error, :handshake_not_finished}
+  defdelegate write_data(dtls, data), to: Native
 
   @doc """
   Handles peer's packets.
@@ -164,12 +164,12 @@ defmodule ExDTLS do
 
   Both local and remote keying materials consist of `master key` and `master salt`.
   """
-  @spec handle_data(dtls(), packets :: binary()) ::
+  @spec handle_data(dtls(), data :: binary()) ::
           {:ok, packets :: binary()}
           | :handshake_want_read
-          | {:handshake_packets, packets :: binary(), timeout :: integer()}
+          | {:handshake_packets, packets :: [binary()], timeout :: integer()}
           | {:handshake_finished, local_keying_material :: binary(),
-             remote_keying_material :: binary(), protection_profile_t(), packets :: binary()}
+             remote_keying_material :: binary(), protection_profile_t(), packets :: [binary()]}
           | {:handshake_finished, local_keying_material :: binary(),
              remote_keying_material :: binary(), protection_profile_t()}
           | {:error, :handshake_error | :peer_closed_for_writing}
@@ -192,6 +192,6 @@ defmodule ExDTLS do
 
   If there is no timeout to handle, simple `{:ok, dtls()}` tuple is returned.
   """
-  @spec handle_timeout(dtls()) :: :ok | {:retransmit, packets :: binary(), timeout :: integer()}
+  @spec handle_timeout(dtls()) :: :ok | {:retransmit, packets :: [binary()], timeout :: integer()}
   defdelegate handle_timeout(dtls), to: Native
 end

--- a/lib/ex_dtls.ex
+++ b/lib/ex_dtls.ex
@@ -175,7 +175,7 @@ defmodule ExDTLS do
           | {:error, :handshake_error | :peer_closed_for_writing}
   def handle_data(dtls, packets) do
     case Native.handle_data(dtls, packets) do
-      {:handshake_finished, lkm, rkm, protection_profile, <<>>} ->
+      {:handshake_finished, lkm, rkm, protection_profile, []} ->
         {:handshake_finished, lkm, rkm, protection_profile}
 
       other ->

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -68,7 +68,7 @@ defmodule ExDTLS.IntegrationTest do
   end
 
   defp loop({dtls1, state1}, {dtls2, state2}, packets) do
-    case ExDTLS.handle_data(dtls1, packets) do
+    case feed_packets(dtls1, packets) do
       {:handshake_packets, packets, _timeout} ->
         loop({dtls2, state2}, {dtls1, state1}, packets)
 
@@ -77,6 +77,13 @@ defmodule ExDTLS.IntegrationTest do
 
       {:handshake_finished, _lkm, _rkm, _p} ->
         loop({dtls2, state2}, {dtls1, true}, packets)
+    end
+  end
+
+  defp feed_packets(dtls, [packet | packets]) do
+    case ExDTLS.handle_data(dtls, packet) do
+      :handshake_want_read -> feed_packets(dtls, packets)
+      other when packets == [] -> other
     end
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,6 +1,7 @@
 defmodule ExDTLS.IntegrationTest do
   use ExUnit.Case, async: true
 
+  @tag :debug
   test "dtls_srtp" do
     rx_dtls = ExDTLS.init(mode: :server, dtls_srtp: true, verify_peer: true)
     tx_dtls = ExDTLS.init(mode: :client, dtls_srtp: true, verify_peer: true)

--- a/test/retransmission_test.exs
+++ b/test/retransmission_test.exs
@@ -10,7 +10,7 @@ defmodule ExDTLS.RetransmissionTest do
     {:retransmit, packets, timeout} = wait_for_timeout(tx_dtls, :tx)
     Process.send_after(self(), {:handle_timeout, :tx}, timeout)
 
-    {:handshake_packets, _packets, timeout} = ExDTLS.handle_data(rx_dtls, packets)
+    {:handshake_packets, _packets, timeout} = feed_packets(rx_dtls, packets)
     Process.send_after(self(), {:handle_timeout, :rx}, timeout)
     {:retransmit, packets, _timeout} = wait_for_timeout(rx_dtls, :rx)
 
@@ -19,7 +19,7 @@ defmodule ExDTLS.RetransmissionTest do
     # and waiting for the old one and handling it can trigger retransmission
     # instead of noop
     Process.sleep(500)
-    {:handshake_packets, _packets, timeout} = ExDTLS.handle_data(tx_dtls, packets)
+    {:handshake_packets, _packets, timeout} = feed_packets(tx_dtls, packets)
     Process.send_after(self(), {:handle_timeout, :tx}, timeout)
     # wait for the old timeout
     :ok = wait_for_timeout(tx_dtls, :tx)
@@ -36,8 +36,18 @@ defmodule ExDTLS.RetransmissionTest do
   end
 
   defp finish_hsk(rx_dtls, tx_dtls, packets) do
-    {:handshake_finished, _lkm, _rkm, _p, packets} = ExDTLS.handle_data(rx_dtls, packets)
-    {:handshake_finished, _lkm, _rkm, _p} = ExDTLS.handle_data(tx_dtls, packets)
+    {:handshake_finished, _lkm, _rkm, _p, packets} = feed_packets(rx_dtls, packets)
+    {:handshake_finished, _lkm, _rkm, _p} = feed_packets(tx_dtls, packets)
     :ok
+  end
+
+  defp feed_packets(dtls, [packet | packets]) do
+    case ExDTLS.handle_data(dtls, packet) do
+      :handshake_want_read -> feed_packets(dtls, packets)
+      # it seems that handshake error (e.g. when a certificate is too old)
+      # may appear before consuming all packets
+      {:error, :handshake_error} = msg -> msg
+      other when packets == [] -> other
+    end
   end
 end


### PR DESCRIPTION
Traditional BIO_s_mem ignores DTLS fragmentation. OpenSSL just appends subsequent datagrams to the BIO_s_mem's buffer, which results in losing packet boundaries. This was greatly pointed out by @spscream in [#31](https://github.com/elixir-webrtc/ex_dtls/issues/31#issuecomment-1794969892) and described by Lorenzo in OpenSSL mailing list: https://mailing.openssl.users.narkive.com/L431ya4W/openssl-users-dtls-fragmentation-and-mem-bio (many thanks  guys!)

Ignoring DTLS fragmentation may result in DTLS datagrams being dropped when MTU size is not large enough. The ServerHello message, in our setup, is ~1400 bytes. When using Orange as ISP, the MTU size seems to be ~1300 bytes so the ServerHello message is dropped. 

Another scenario where our implementation fails is when we use 4096 bits certificate.

To mitigate this issue, we can:
* use BIO_s_dgram_mem, which respects packet boundaries. This however, seems to be introduced in OpenSSL 3 so the solution might not be supported on older platforms. 
* implement custom filter as described in https://mailing.openssl.users.narkive.com/L431ya4W/openssl-users-dtls-fragmentation-and-mem-bio

OpenSSL 1.1 EOL was in September 2023. Ubuntu was providing security fixes in Ubuntu 20.04 until [04.2025](https://ubuntu.com/blog/running-openssl-1-1-1-after-eol-with-ubuntu-pro) (not including pro subscribers, who are receiving security updates for 10 years). Newer versions, like 22.04, migrated to OpenSSL 3. ~~Hence, we chose the first option (using BIO_s_dgram_mem). If we see anyone still using OpenSSL 1.1, we will consider providing backward compatible solution.~~ Looks like `ubuntu-latest` with OTP 26 uses OpenSSL 1.1 (that's the config from our CI) so we go for custom filter.

The MTU is hardcoded to 1200.

Resources: 
* https://github.com/openssl/openssl/blob/871182d29dc24bbb51ff7a4d952ff9d9868f14b5/crypto/evp/bio_md.c#L4 
* https://github.com/meetecho/janus-gateway/blob/505d97d7fee6bc6370f28bf5e51d491cc5716b27/src/dtls-bio.c#L20
* https://github.com/openssl/openssl/blob/29eb7e0689b9c4231d9603a7d19475bed216d779/crypto/bio/bss_dgram_pair.c#L238
* https://chromium.googlesource.com/chromium/deps/openssl/+/f0c775a4f902aca6abb5d4b1d5ba3260adf73541/openssl/include/openssl/bio.h

Fixes #31 